### PR TITLE
Add featured images to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The `events` themselves contain the following properties (single events are avai
 - `location_city` City.
 - `location_country` Country.
 - `location_misc` Miscellaneous information (e.g. "The door is on the back of the house").
+- `featured_images` Featured images for the event.
 
 ## License
 

--- a/components/Calendar.php
+++ b/components/Calendar.php
@@ -73,7 +73,7 @@ class Calendar extends \Cms\Classes\ComponentBase
         $this->page->campaignrMonth = $month;
         $this->page->campaignrYear = $year;
 
-        return Event::with(['featured_images'])->all();
+        return Event::with(['featured_images'])->get();
     }
 
     /**

--- a/components/Calendar.php
+++ b/components/Calendar.php
@@ -73,7 +73,7 @@ class Calendar extends \Cms\Classes\ComponentBase
         $this->page->campaignrMonth = $month;
         $this->page->campaignrYear = $year;
 
-        return Event::all();
+        return Event::with(['featured_images'])->all();
     }
 
     /**

--- a/components/EventComponent.php
+++ b/components/EventComponent.php
@@ -58,7 +58,7 @@ class EventComponent extends \Cms\Classes\ComponentBase
     // This array becomes available on the page as {{ component.event }}
     public function event()
     {
-        return Event::where('slug', $this->property('eventSlug'))->get()->first();
+        return Event::with(['featured_images'])->where('slug', $this->property('eventSlug'))->get()->first();
     }
 
 

--- a/components/Upcoming.php
+++ b/components/Upcoming.php
@@ -54,7 +54,7 @@ class Upcoming extends \Cms\Classes\ComponentBase
     // This array becomes available on the page as {{ component.events }}
     public function events()
     {
-        $events = Event::all();
+        $events = Event::with(['featured_images'])->all();
         $ret = [];
 
         // Only include those events that do occur in the future (either single

--- a/components/Upcoming.php
+++ b/components/Upcoming.php
@@ -54,7 +54,7 @@ class Upcoming extends \Cms\Classes\ComponentBase
     // This array becomes available on the page as {{ component.events }}
     public function events()
     {
-        $events = Event::with(['featured_images'])->all();
+        $events = Event::with(['featured_images'])->get();
         $ret = [];
 
         // Only include those events that do occur in the future (either single

--- a/components/eventcomponent/default.htm
+++ b/components/eventcomponent/default.htm
@@ -1,5 +1,10 @@
 {% set event = __SELF__.event %}
 
+{% if event.featured_images.count %}
+  {% for image in event.featured_images %}
+    <img src="{{ image.getPath() }}" alt="{{ image.title | default(image.file_name) }}" />
+  {% endfor %}
+{% endif %}
 <h1>{{ event.name }}</h1>
 <p class="campaignr-event-date">
   {% if event.repeat_event and event.repeat_mode > 0 %}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -37,6 +37,7 @@ return [
             'misc_comment' => 'Additional information pertaining the location of the event.',
         ],
         'should_repeat' => 'Repeat?',
+        'featured_images' => 'Featured images',
     ],
     'components' => [
         'calendar' => [

--- a/models/Event.php
+++ b/models/Event.php
@@ -62,6 +62,13 @@ class Event extends Model
     public $rules = [];
 
     /**
+     * @var array Allow attachment of featured images
+     */
+    public $attachMany = [
+      'featured_images' => ['System\Models\File', 'order' => 'sort_order']
+    ];
+
+    /**
      * Holds the next occurrence of this event, if the function getNextOccurrence
      * has been called and has returned true.
      * @var string

--- a/models/event/fields.yaml
+++ b/models/event/fields.yaml
@@ -18,6 +18,13 @@ fields:
         type: partial
         path: event_toolbar
         cssClass: collapse-visible
+    featured_images:
+        label: hendrikerz.campaignr::lang.fields.featured_images
+        type: fileupload
+        mode: image
+        imageWidth: 200
+        imageHeight: 200
+        tab: 'hendrikerz.campaignr::lang.fields.tab_details'
 secondaryTabs:
     fields:
         time_begin:


### PR DESCRIPTION
Hey, thanks for this plugin - it's great!

This PR adds support for featured images on events, in a very similar way to how it's implemented in Rainlab/Blog. The implementation I've put in the default component is very basic, fitting with the rest of the component, but this has some pretty obvious potential uses in lists of events or for social sharing cards in customised versions - hence I've included `featured_images` in the load for the other components too.