### PR TITLE
Only take possibly-future events in Upcoming.php SQL

### DIFF
--- a/components/Upcoming.php
+++ b/components/Upcoming.php
@@ -54,7 +54,11 @@ class Upcoming extends \Cms\Classes\ComponentBase
     // This array becomes available on the page as {{ component.events }}
     public function events()
     {
-        $events = Event::all();
+        // Make sure we only include single events in the future, or active repeating events.
+        $timestamp = Carbon::now();
+        $events = Event::where(function($query) use ($timestamp) {
+          $query->where('repeat_event', true)->where('end_repeat_on', '>=', $timestamp);
+        })->orWhere('time_begin', '>=', $timestamp)->get();
         $ret = [];
 
         // Only include those events that do occur in the future (either single


### PR DESCRIPTION
This PR improves efficiency in Upcoming.php by only requesting from the database those events which might occur in the future, rather than sorting through all events, including those which have no chance of happening again.